### PR TITLE
Use labels instead of env

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Forward requests coming from your Docker network(s) to the running agent:
 $ iptables -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination "$GATEWAY":8080 -i "$INTERFACE"
 ```
 
-When starting containers, set their `IAM_PROFILE` environment variable:
+When starting containers, set their `IAM_PROFILE` label variable:
 
 ```bash
 $ export IMAGE="ubuntu:latest"
 $ export PROFILE="arn:aws:iam::1234123412:role/some-role"
-$ docker run -e IAM_PROFILE="$PROFILE" "$IMAGE"
+$ docker run --label IAM_PROFILE="$PROFILE" "$IMAGE"
 ```
 
 ## How it works
 
 The application listens to the [Docker events stream](https://docs.docker.com/engine/reference/commandline/events/) for container start events.
-When a container is started with an `IAM_PROFILE` environment variable, the application assumes that role (if possible).
+When a container is started with an `IAM_PROFILE` label, the application assumes that role (if possible).
 When the container makes an [EC2 Metadata API](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) EC2 metadata API request, it's forwarded to the application because of the `iptables` rule above.
 If the request is for IAM credentials, the application intercepts that and determines which credentials should be passed back to the container.
 Otherwise, it acts as a reverse proxy to the real metadata API.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project allows Docker containers to use different EC2 instance roles.
 You can pull release images from [Docker Hub](https://hub.docker.com/r/swipely/iam-docker/).
 
-![Example gif](https://s3.amazonaws.com/swipely-pub/public-images/iam-docker-cast.gif)
+![Example gif](https://s3.amazonaws.com/swipely-pub/public-images/iam-docker-latest.gif)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Forward requests coming from your Docker network(s) to the running agent:
 $ iptables -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination "$GATEWAY":8080 -i "$INTERFACE"
 ```
 
-When starting containers, set their `IAM_PROFILE` label variable:
+When starting containers, set their `com.swipely.iam-docker.iam-profile` label:
 
 ```bash
 $ export IMAGE="ubuntu:latest"
 $ export PROFILE="arn:aws:iam::1234123412:role/some-role"
-$ docker run --label IAM_PROFILE="$PROFILE" "$IMAGE"
+$ docker run --label com.swipely.iam-docker.iam-profile="$PROFILE" "$IMAGE"
 ```
 
 ## How it works
 
 The application listens to the [Docker events stream](https://docs.docker.com/engine/reference/commandline/events/) for container start events.
-When a container is started with an `IAM_PROFILE` label, the application assumes that role (if possible).
+When a container is started with an `com.swipely.iam-docker.iam-profile` label, the application assumes that role (if possible).
 When the container makes an [EC2 Metadata API](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) EC2 metadata API request, it's forwarded to the application because of the `iptables` rule above.
 If the request is for IAM credentials, the application intercepts that and determines which credentials should be passed back to the container.
 Otherwise, it acts as a reverse proxy to the real metadata API.

--- a/src/docker/container_store.go
+++ b/src/docker/container_store.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	iamLabel             = "IAM_PROFILE"
+	iamLabel             = "com.swipely.iam-docker.iam-profile"
 	retrySleepBase       = time.Second
 	retrySleepMultiplier = 2
 	maxRetries           = 3
@@ -166,7 +166,7 @@ func (store *containerStore) findConfigForID(id string) (*containerConfig, error
 
 	iamRole, hasKey := container.Config.Labels[iamLabel]
 	if !hasKey {
-		return nil, fmt.Errorf("Unable to find label named IAM_PROFILE for container: %s", id)
+		return nil, fmt.Errorf("Unable to find label named '%s' for container: %s", iamLabel, id)
 	}
 	ip := container.NetworkSettings.IPAddress
 	config := &containerConfig{

--- a/src/docker/container_store_test.go
+++ b/src/docker/container_store_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ContainerStore", func() {
 				err := client.AddContainer(&dockerClient.Container{
 					ID: id,
 					Config: &dockerClient.Config{
-						Labels: map[string]string{"IAM_PROFILE": role},
+						Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role},
 					},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
@@ -79,17 +79,17 @@ var _ = Describe("ContainerStore", func() {
 		BeforeEach(func() {
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "DEADBEEF",
-				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/alpha"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": "arn:aws:iam::012345678901:role/alpha"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.2"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "FEEDABEE",
-				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/beta"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": "arn:aws:iam::012345678901:role/beta"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.3"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "CA55E77E",
-				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/alpha"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": "arn:aws:iam::012345678901:role/alpha"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.4"},
 			})
 			_ = subject.SyncRunningContainers()
@@ -124,7 +124,7 @@ var _ = Describe("ContainerStore", func() {
 			BeforeEach(func() {
 				_ = client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": role}},
+					Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.2"},
 				})
 				_ = subject.SyncRunningContainers()
@@ -157,7 +157,7 @@ var _ = Describe("ContainerStore", func() {
 			BeforeEach(func() {
 				_ = client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": role}},
+					Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
 				_ = subject.SyncRunningContainers()
@@ -194,7 +194,7 @@ var _ = Describe("ContainerStore", func() {
 			BeforeEach(func() {
 				_ = client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": role}},
+					Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
 				_ = subject.SyncRunningContainers()
@@ -216,12 +216,12 @@ var _ = Describe("ContainerStore", func() {
 		BeforeEach(func() {
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "38BE1290",
-				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/reader"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": "arn:aws:iam::012345678901:role/reader"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.15"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "EF10A722",
-				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/writer"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": "arn:aws:iam::012345678901:role/writer"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.16"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{

--- a/src/docker/container_store_test.go
+++ b/src/docker/container_store_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ContainerStore", func() {
 			BeforeEach(func() {
 				err := client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Env: []string{}},
+					Config:          &dockerClient.Config{Labels: map[string]string{}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
 				Expect(err).To(BeNil())
@@ -54,7 +54,7 @@ var _ = Describe("ContainerStore", func() {
 				err := client.AddContainer(&dockerClient.Container{
 					ID: id,
 					Config: &dockerClient.Config{
-						Env: []string{"IAM_PROFILE=" + role},
+						Labels: map[string]string{"IAM_PROFILE": role},
 					},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
@@ -79,17 +79,17 @@ var _ = Describe("ContainerStore", func() {
 		BeforeEach(func() {
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "DEADBEEF",
-				Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=arn:aws:iam::012345678901:role/alpha"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/alpha"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.2"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "FEEDABEE",
-				Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=arn:aws:iam::012345678901:role/beta"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/beta"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.3"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "CA55E77E",
-				Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=arn:aws:iam::012345678901:role/alpha"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/alpha"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.4"},
 			})
 			_ = subject.SyncRunningContainers()
@@ -124,7 +124,7 @@ var _ = Describe("ContainerStore", func() {
 			BeforeEach(func() {
 				_ = client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=" + role}},
+					Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": role}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.2"},
 				})
 				_ = subject.SyncRunningContainers()
@@ -157,7 +157,7 @@ var _ = Describe("ContainerStore", func() {
 			BeforeEach(func() {
 				_ = client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=" + role}},
+					Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": role}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
 				_ = subject.SyncRunningContainers()
@@ -192,9 +192,9 @@ var _ = Describe("ContainerStore", func() {
 
 		Context("When the ID is stored", func() {
 			BeforeEach(func() {
-				client.AddContainer(&dockerClient.Container{
+				_ = client.AddContainer(&dockerClient.Container{
 					ID:              id,
-					Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=" + role}},
+					Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": role}},
 					NetworkSettings: &dockerClient.NetworkSettings{IPAddress: ip},
 				})
 				_ = subject.SyncRunningContainers()
@@ -216,17 +216,17 @@ var _ = Describe("ContainerStore", func() {
 		BeforeEach(func() {
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "38BE1290",
-				Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=arn:aws:iam::012345678901:role/reader"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/reader"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.15"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "EF10A722",
-				Config:          &dockerClient.Config{Env: []string{"IAM_PROFILE=arn:aws:iam::012345678901:role/writer"}},
+				Config:          &dockerClient.Config{Labels: map[string]string{"IAM_PROFILE": "arn:aws:iam::012345678901:role/writer"}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.16"},
 			})
 			_ = client.AddContainer(&dockerClient.Container{
 				ID:              "F00DF00D",
-				Config:          &dockerClient.Config{Env: []string{}},
+				Config:          &dockerClient.Config{Labels: map[string]string{}},
 				NetworkSettings: &dockerClient.NetworkSettings{IPAddress: "172.0.0.17"},
 			})
 		})

--- a/src/docker/event_handler_test.go
+++ b/src/docker/event_handler_test.go
@@ -51,7 +51,7 @@ var _ = Describe("EventHandler", func() {
 					ip = "172.17.0.2"
 					_ = dockerClient.AddContainer(&docker.Container{
 						ID:              id,
-						Config:          &docker.Config{Env: []string{}},
+						Config:          &docker.Config{Labels: map[string]string{}},
 						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
 					})
 				})
@@ -84,7 +84,7 @@ var _ = Describe("EventHandler", func() {
 					}
 					_ = dockerClient.AddContainer(&docker.Container{
 						ID:              id,
-						Config:          &docker.Config{Env: []string{"IAM_PROFILE=" + role}},
+						Config:          &docker.Config{Labels: map[string]string{"IAM_PROFILE": role}},
 						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
 					})
 				})
@@ -105,7 +105,7 @@ var _ = Describe("EventHandler", func() {
 					ip = "172.17.0.4"
 					_ = dockerClient.AddContainer(&docker.Container{
 						ID:              id,
-						Config:          &docker.Config{Env: []string{}},
+						Config:          &docker.Config{Labels: map[string]string{}},
 						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
 					})
 				})
@@ -141,7 +141,7 @@ var _ = Describe("EventHandler", func() {
 					}
 					_ = dockerClient.AddContainer(&docker.Container{
 						ID:              id,
-						Config:          &docker.Config{Env: []string{"IAM_PROFILE=" + role}},
+						Config:          &docker.Config{Labels: map[string]string{"IAM_PROFILE": role}},
 						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
 					})
 					_ = dockerClient.RemoveContainer(id)

--- a/src/docker/event_handler_test.go
+++ b/src/docker/event_handler_test.go
@@ -45,7 +45,7 @@ var _ = Describe("EventHandler", func() {
 		)
 
 		Context("When a start event is received", func() {
-			Context("When the container does not have an IAM_PROFILE set", func() {
+			Context("When the container does not have an com.swipely.iam-docker.iam-profile set", func() {
 				BeforeEach(func() {
 					id = "CA55E77E"
 					ip = "172.17.0.2"
@@ -64,7 +64,7 @@ var _ = Describe("EventHandler", func() {
 				})
 			})
 
-			Context("When the container has an IAM_PROFILE set", func() {
+			Context("When the container has an com.swipely.iam-docker.iam-profile set", func() {
 				var (
 					role            = "test-role"
 					accessKeyID     = "test-access-key-id"
@@ -84,7 +84,7 @@ var _ = Describe("EventHandler", func() {
 					}
 					_ = dockerClient.AddContainer(&docker.Container{
 						ID:              id,
-						Config:          &docker.Config{Labels: map[string]string{"IAM_PROFILE": role}},
+						Config:          &docker.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
 						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
 					})
 				})
@@ -141,7 +141,7 @@ var _ = Describe("EventHandler", func() {
 					}
 					_ = dockerClient.AddContainer(&docker.Container{
 						ID:              id,
-						Config:          &docker.Config{Labels: map[string]string{"IAM_PROFILE": role}},
+						Config:          &docker.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
 						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
 					})
 					_ = dockerClient.RemoveContainer(id)

--- a/src/docker/event_handler_test.go
+++ b/src/docker/event_handler_test.go
@@ -45,7 +45,7 @@ var _ = Describe("EventHandler", func() {
 		)
 
 		Context("When a start event is received", func() {
-			Context("When the container does not have an com.swipely.iam-docker.iam-profile set", func() {
+			Context("When the container does not have com.swipely.iam-docker.iam-profile set", func() {
 				BeforeEach(func() {
 					id = "CA55E77E"
 					ip = "172.17.0.2"
@@ -64,7 +64,7 @@ var _ = Describe("EventHandler", func() {
 				})
 			})
 
-			Context("When the container has an com.swipely.iam-docker.iam-profile set", func() {
+			Context("When the container has com.swipely.iam-docker.iam-profile set", func() {
 				var (
 					role            = "test-role"
 					accessKeyID     = "test-access-key-id"

--- a/src/http/handler_test.go
+++ b/src/http/handler_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Handler", func() {
 					_ = dockerClient.AddContainer(&dockerlib.Container{
 						ID: containerID,
 						Config: &dockerlib.Config{
-							Env: []string{"IAM_PROFILE=" + iamRole},
+							Labels: map[string]string{"IAM_PROFILE": iamRole},
 						},
 						NetworkSettings: &dockerlib.NetworkSettings{
 							IPAddress: ip,
@@ -163,7 +163,7 @@ var _ = Describe("Handler", func() {
 					_ = dockerClient.AddContainer(&dockerlib.Container{
 						ID: containerID,
 						Config: &dockerlib.Config{
-							Env: []string{"IAM_PROFILE=" + iamRole},
+							Labels: map[string]string{"IAM_PROFILE": iamRole},
 						},
 						NetworkSettings: &dockerlib.NetworkSettings{
 							IPAddress: ip,

--- a/src/http/handler_test.go
+++ b/src/http/handler_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Handler", func() {
 					_ = dockerClient.AddContainer(&dockerlib.Container{
 						ID: containerID,
 						Config: &dockerlib.Config{
-							Labels: map[string]string{"IAM_PROFILE": iamRole},
+							Labels: map[string]string{"com.swipely.iam-docker.iam-profile": iamRole},
 						},
 						NetworkSettings: &dockerlib.NetworkSettings{
 							IPAddress: ip,
@@ -163,7 +163,7 @@ var _ = Describe("Handler", func() {
 					_ = dockerClient.AddContainer(&dockerlib.Container{
 						ID: containerID,
 						Config: &dockerlib.Config{
-							Labels: map[string]string{"IAM_PROFILE": iamRole},
+							Labels: map[string]string{"com.swipely.iam-docker.iam-profile": iamRole},
 						},
 						NetworkSettings: &dockerlib.NetworkSettings{
 							IPAddress: ip,


### PR DESCRIPTION
@adamjt @bfulton @tlunter 

Use [Docker Container Labels](https://docs.docker.com/engine/userguide/labels-custom-metadata/) instead of environment variables for setting the `IAM_PROFILE`.
Labels are specifically meant for external metadata, which is a better fit for this use case.

