### PR TITLE
Refresh IAM credentials every half hour

### DIFF
--- a/src/iam/credential_store.go
+++ b/src/iam/credential_store.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	refreshGracePeriod  = time.Minute * 10
+	refreshGracePeriod  = time.Minute * 30
 	realTimeGracePeriod = time.Second * 10
 )
 


### PR DESCRIPTION
@tlunter 

Some Amazon client libraries (like the Kinesis client library) refresh
credentilas when they'll expire in the next 15 minutes. A refresh every
30 minutes should keep iam-docker as fresh as they need without
refreshing during a request.