### PR TITLE
Use a container's networks to find IP addresses

### DIFF
--- a/src/docker/event_handler_test.go
+++ b/src/docker/event_handler_test.go
@@ -50,9 +50,15 @@ var _ = Describe("EventHandler", func() {
 					id = "CA55E77E"
 					ip = "172.17.0.2"
 					_ = dockerClient.AddContainer(&docker.Container{
-						ID:              id,
-						Config:          &docker.Config{Labels: map[string]string{}},
-						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
+						ID:     id,
+						Config: &docker.Config{Labels: map[string]string{}},
+						NetworkSettings: &docker.NetworkSettings{
+							Networks: map[string]docker.ContainerNetwork{
+								"bridge": docker.ContainerNetwork{
+									IPAddress: ip,
+								},
+							},
+						},
 					})
 				})
 
@@ -83,9 +89,15 @@ var _ = Describe("EventHandler", func() {
 						SessionToken:    &sessionToken,
 					}
 					_ = dockerClient.AddContainer(&docker.Container{
-						ID:              id,
-						Config:          &docker.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
-						NetworkSettings: &docker.NetworkSettings{IPAddress: ip},
+						ID:     id,
+						Config: &docker.Config{Labels: map[string]string{"com.swipely.iam-docker.iam-profile": role}},
+						NetworkSettings: &docker.NetworkSettings{
+							Networks: map[string]docker.ContainerNetwork{
+								"bridge": docker.ContainerNetwork{
+									IPAddress: ip,
+								},
+							},
+						},
 					})
 				})
 


### PR DESCRIPTION
When adding a container, the container store would look for the top
level `IPAddress` field to find its IP. This works when the container is
using the default network, but fails when the container is using a
custom network. The container store now fetches the IPAddress field from
each network to determine the IPs associated with the container.

@tlunter: Please review.
@patagona-afriemann: Could you please validate that this works for your setup? I pushed the image to Docker Hub as ` swipely/iam-docker:56f9162`.