### PR TITLE
Support IAM_ROLE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ $ export PROFILE="arn:aws:iam::1234123412:role/some-role"
 $ docker run --label com.swipely.iam-docker.iam-profile="$PROFILE" "$IMAGE"
 ```
 
+Alternately, set the `IAM_ROLE` environment variable:
+
+```bash
+$ export IMAGE="ubuntu:latest"
+$ export PROFILE="arn:aws:iam::1234123412:role/some-role"
+$ docker run -e IAM_ROLE="$PROFILE" "$IMAGE"
+```
+
 ## How it works
 
 The application listens to the [Docker events stream](https://docs.docker.com/engine/reference/commandline/events/) for container start events.


### PR DESCRIPTION
Some non-ECS environments make it difficult to specify Docker labels but easy to specify environment variables. This commit makes `iam-docker` look for the `IAM_ROLE` environment variable if no label is available.

Incidentally, this change also allows `iam-docker` to act as a drop-in replacement for [`lyft/metadataproxy`](https://github.com/lyft/metadataproxy).