### PR TITLE
Switch to a multi-stage build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1-alpine AS builder
+
+RUN apk add --no-cache curl
+
+# Make a /target directory which we'll copy into the target image as a single layer, and
+# populate it with some SSL roots
+RUN mkdir -p /target/etc/ssl/certs && \
+	curl -s -o /target/etc/ssl/certs/ca-certificates.crt https://curl.haxx.se/ca/cacert.pem
+
+# Copy in the app
+ENV CGO_ENABLED=0
+WORKDIR /go/src/github.com/swipely/iam-docker/
+ADD . .
+
+# Run tests
+RUN go test -v ./...
+
+# Build the app via `go install`, copy the binary to /target/iam-docker, and copy the license file
+RUN go install ./... && \
+	cp /go/bin/src /target/iam-docker && \
+	cp LICENSE /target/
+
+# Build the final image
+FROM scratch
+MAINTAINER Tom Hulihan (hulihan.tom159@gmail.com)
+COPY --from=builder /target /
+ENTRYPOINT ["/iam-docker"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,0 @@
-FROM golang:1.6
-MAINTAINER Tom Hulihan (hulihan.tom159@gmail.com)
-ADD . /go/src/github.com/swipely/iam-docker/
-WORKDIR /go/src/github.com/swipely/iam-docker/
-RUN make get-deps

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,0 @@
-FROM scratch
-MAINTAINER Tom Hulihan (hulihan.tom159@gmail.com)
-ADD ./LICENSE /
-ADD ./dist/iam-docker /
-ADD ./dist/ca-certificates.crt /etc/ssl/certs/
-ENV GOMAXPROCS 4
-CMD ["/iam-docker"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,5 @@ Commonly used commands:
 * `make get-deps` - install the system dependencies
 * `make test` - run the application tests
 * `make docker` - build a release Docker image
-* `make test-in-docker` - run the tests in Docker
 
 All source code is in the `src/` directory.


### PR DESCRIPTION
Docker supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/). This PR changes `iam-docker` to use that feature.

The target image is still `FROM scratch`, so the output is just like it was before – but instead of needing `make` to drive the process, everything happens in `docker build`. Building even does `go test` now too:

```console
$ docker build -t iam-docker .
Sending build context to Docker daemon  21.05MB
Step 1/12 : FROM golang:1-alpine AS builder
…
Step 7/12 : RUN go test -v ./...
…
Step 9/12 : FROM scratch
…
Successfully built 8eb65057d3d8
Successfully tagged iam-docker:latest

$ docker images | grep iam-docker
iam-docker                           latest              8eb65057d3d8        About a minute ago   9.23MB
swipely/iam-docker                   latest              272535b48f30        14 months ago        14MB
```

I trimmed down the `Makefile`, but basically now all it does is:

* `make test` => `go test ./...`
* `make docker` => `docker build -t swipely/iam-docker .`

A side effect of this PR is that `iam-docker` can now use [Docker Hub's automated build system](https://docs.docker.com/docker-hub/builds/), at which point the `Makefile` could probably be discarded entirely.